### PR TITLE
[DCFS-7] Relations and foreign keys

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="@localhost" uuid="520d7895-c7b1-4230-86db-5389e7a369ff">
+      <driver-ref>mariadb</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.mariadb.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mariadb://localhost:3306</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/db/dbo/block.go
+++ b/db/dbo/block.go
@@ -1,0 +1,23 @@
+package dbo
+
+import (
+	"github.com/google/uuid"
+)
+
+type Block struct {
+	AbstractDatabaseObject
+	UserUUID   uuid.UUID
+	VolumeUUID uuid.UUID
+	DiskUUID   uuid.UUID
+	size       int
+	checksum   int
+
+	Volume Volume `gorm:"foreignKey:VolumeUUID;references:UUID"`
+	Disk   Disk   `gorm:"foreignKey:DiskUUID;references:UUID"`
+}
+
+func NewBlock() *Block {
+	var f *Block = new(Block)
+	f.AbstractDatabaseObject.DatabaseObject = f
+	return f
+}

--- a/db/dbo/disk.go
+++ b/db/dbo/disk.go
@@ -8,6 +8,9 @@ type Disk struct {
 	VolumeUUID   uuid.UUID
 	ProviderUUID uuid.UUID
 	Credentials  string
+
+	Volume   Volume   `gorm:"foreignKey:VolumeUUID;references:UUID"`
+	Provider Provider `gorm:"foreignKey:ProviderUUID;references:UUID"`
 }
 
 func NewDisk() *Disk {

--- a/db/dbo/interface.go
+++ b/db/dbo/interface.go
@@ -9,5 +9,5 @@ type DatabaseObject interface {
 
 type AbstractDatabaseObject struct {
 	DatabaseObject `gorm:"-"`
-	UUID           uuid.UUID `gorm:"primaryKey"`
+	UUID           uuid.UUID `gorm:"primaryKey;type:varchar(32)"`
 }

--- a/main.go
+++ b/main.go
@@ -31,9 +31,10 @@ func main() {
 
 	// Register all needed tables
 	db.DB.RegisterTable(dbo.Volume{})
+	db.DB.RegisterTable(dbo.Provider{})
 	db.DB.RegisterTable(dbo.File{})
 	db.DB.RegisterTable(dbo.Disk{})
-	db.DB.RegisterTable(dbo.Provider{})
+	db.DB.RegisterTable(dbo.Block{})
 
 	if *rspw {
 		err = db.DB.Respawn()


### PR DESCRIPTION
Add foreign keys and relations to models: Block, Disk.
Fix problems with migrating relations by specifying DB type of UUID in AbstractDatabaseObject - VARCHAR(32).

Currently migrated database has the following layout:
![obraz](https://user-images.githubusercontent.com/57873253/190871587-5e0d7b71-9531-435d-93cd-05bed2994f20.png)
