### PR TITLE
[DCFS-102] CreatedAt field should not be updated on save

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -73,7 +73,7 @@ func ServeBackend() {
 		authorized.DELETE("/file/manage/:FileUUID", FileRemove)
 		authorized.GET("/file/manage/:FileUUID", FileGet)
 
-		authorized.GET("/file/request", FileRequest)
+		authorized.POST("/file/request", FileRequest)
 		authorized.POST("/file/request/complete/:FileUUID", FileRequestComplete)
 
 		authorized.POST("/file/share/:FileUUID", FileShare)

--- a/db/dbo/disk.go
+++ b/db/dbo/disk.go
@@ -13,7 +13,7 @@ type Disk struct {
 	Credentials  string    `json:"credentials"`
 	Name         string    `json:"name"`
 
-	CreatedAt time.Time `json:"-"`
+	CreatedAt time.Time `gorm:"<-:create" json:"-"`
 
 	User     User     `gorm:"foreignKey:UserUUID;references:UUID" json:"user"`
 	Volume   Volume   `gorm:"foreignKey:VolumeUUID;references:UUID" json:"volume"`

--- a/db/dbo/volume.go
+++ b/db/dbo/volume.go
@@ -19,7 +19,7 @@ type Volume struct {
 	UserUUID       uuid.UUID      `json:"-"`
 	VolumeSettings VolumeSettings `gorm:"embedded" json:"settings"`
 
-	CreatedAt time.Time      `json:"-"`
+	CreatedAt time.Time      `gorm:"<-:create" json:"-"`
 	DeletedAt gorm.DeletedAt `json:"-"`
 
 	User User `gorm:"foreignKey:UserUUID;references:UUID" json:"-"`


### PR DESCRIPTION
Gorm has a bug in Save method which results in updating all fields (including CreatedAt). 
As a result CreatedAt field is filled with zeros which is incompatible with MySQL.