### PR TITLE
[DCFS-125] Deletion operation

### DIFF
--- a/constants/completionCodes.go
+++ b/constants/completionCodes.go
@@ -61,6 +61,7 @@ const (
 	FS_FILE_TYPE_MISMATCH  = "FS-012"
 	FS_BLOCK_UPLOAD_FAILED = "FS-020"
 	FS_BAD_FILE            = "FS-030"
+	FS_DIRECTORY_NOT_EMPTY = "FS-040"
 
 	// Ownership errors
 	OWNER_MISMATCH = "OWN-001"

--- a/constants/completionCodes.go
+++ b/constants/completionCodes.go
@@ -76,4 +76,5 @@ const (
 
 	// Operation errors
 	OPERATION_NOT_SUPPORTED = "OP-000"
+	OPERATION_FAILED        = "OP-001"
 )

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -59,3 +59,9 @@ const (
 	DEFAULT_VOLUME_BLOCK_SIZE int = 8 * 1024 * 1024
 	FRONT_RAM_CAPACITY        int = 8 * 1024 * 1024
 )
+
+// Deletion constants
+const (
+	DELETION   bool = false
+	RELOCATION bool = true
+)

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -75,7 +75,7 @@ func ServeBackend() {
 		authorized.GET("/files/block/:BlockUUID", DownloadBlock)
 
 		authorized.PUT("/files/manage/:FileUUID", UpdateFile)
-		//authorized.DELETE("/files/manage/:FileUUID", DeleteFile)
+		authorized.DELETE("/files/manage/:FileUUID", DeleteFile)
 
 		// Providers
 		authorized.GET("/providers", GetProviders)

--- a/controllers/disk.go
+++ b/controllers/disk.go
@@ -443,14 +443,14 @@ func DeleteDisk(c *gin.Context) {
 	}
 
 	// Retrieve volume from transport
-	_v := models.Transport.GetVolume(_d.GetVolume().UUID)
-	if _v == nil {
+	volume := models.Transport.GetVolume(_disk.VolumeUUID)
+	if volume == nil {
 		c.JSON(404, responses.NewNotFoundErrorResponse(constants.TRANSPORT_VOLUME_NOT_FOUND, "Volume not found"))
 		return
 	}
 
 	// Trigger delete process
-	errCode, err := models.Transport.DeleteDisk(_d, _v, constants.DELETION)
+	errCode, err := models.Transport.DeleteDisk(volume.GetDisk(_disk.UUID), volume, constants.DELETION)
 
 	if errCode != constants.SUCCESS {
 		c.JSON(500, responses.NewOperationFailureResponse(errCode, "Deletion of the disk failed: "+err.Error()))

--- a/controllers/disk.go
+++ b/controllers/disk.go
@@ -423,8 +423,6 @@ func UpdateDisk(c *gin.Context) {
 func DeleteDisk(c *gin.Context) {
 	var _diskUUID string
 	var _disk dbo.Disk
-	var _blocks []dbo.Block
-	var volume *models.Volume
 	var err error
 
 	// Retrieve disk from database
@@ -444,28 +442,21 @@ func DeleteDisk(c *gin.Context) {
 		return
 	}
 
-	// Check whether disk is empty
-	err = db.DB.DatabaseHandle.Where("disk_uuid = ?", _diskUUID).Find(&_blocks).Error
-	if err != nil {
-		logger.Logger.Error("api", "Could not check for blocks on the disk with the uuid: ", _diskUUID, " in the db.")
-		c.JSON(500, responses.NewOperationFailureResponse(constants.DATABASE_ERROR, "Could not query the database"))
+	// Retrieve volume from transport
+	_v := models.Transport.GetVolume(_d.GetVolume().UUID)
+	if _v == nil {
+		c.JSON(404, responses.NewNotFoundErrorResponse(constants.TRANSPORT_VOLUME_NOT_FOUND, "Volume not found"))
 		return
 	}
 
-	if len(_blocks) > 0 {
-		logger.Logger.Error("api", "The provided disk with the uuid: ", _diskUUID, " is not empty and thus cannot be deleted.")
-		c.JSON(405, responses.NewOperationFailureResponse(constants.TRANSPORT_DISK_IS_BEING_USED, "The provided disk is not empty and thus cannot be deleted"))
+	// Trigger delete process
+	errCode, err := models.Transport.DeleteDisk(_d, _v, constants.DELETION)
+
+	if errCode != constants.SUCCESS {
+		c.JSON(500, responses.NewOperationFailureResponse(errCode, "Deletion of the disk failed: "+err.Error()))
 		return
 	}
 
-	// Trigger disk deletion
-	volume = models.Transport.GetVolume(_disk.Volume.UUID)
-	volume.DeleteDisk(_disk.UUID)
-	db.DB.DatabaseHandle.Where("uuid = ?", _diskUUID).Delete(&_disk)
-
-	go volume.RefreshPartitioner()
-
-	logger.Logger.Debug("api", "DeleteDisk endpoint successful exit.")
 	c.JSON(200, responses.NewSuccessResponse(_disk))
 }
 

--- a/controllers/disk.go
+++ b/controllers/disk.go
@@ -423,6 +423,7 @@ func UpdateDisk(c *gin.Context) {
 func DeleteDisk(c *gin.Context) {
 	var _diskUUID string
 	var _disk dbo.Disk
+	var userUUID uuid.UUID
 	var err error
 
 	// Retrieve disk from database
@@ -431,6 +432,15 @@ func DeleteDisk(c *gin.Context) {
 	if err != nil {
 		logger.Logger.Error("api", "Could not find a disk with the provided uuid: ", _diskUUID, " in the db.")
 		c.JSON(404, responses.NewNotFoundErrorResponse(constants.DATABASE_DISK_NOT_FOUND, "Could not find the disk with the provided UUID"))
+		return
+	}
+
+	// Retrieve userUUID from context
+	userUUID = c.MustGet("UserData").(middleware.UserData).UserUUID
+
+	// Verify that the user is owner of the volume
+	if userUUID != _disk.UserUUID {
+		c.JSON(404, responses.NewNotFoundErrorResponse(constants.OWNER_MISMATCH, "Disk not found"))
 		return
 	}
 

--- a/controllers/disk.go
+++ b/controllers/disk.go
@@ -467,6 +467,9 @@ func DeleteDisk(c *gin.Context) {
 		return
 	}
 
+	// Refresh volume partitioner after disk list change
+	go volume.RefreshPartitioner()
+
 	c.JSON(200, responses.NewSuccessResponse(_disk))
 }
 

--- a/controllers/file.go
+++ b/controllers/file.go
@@ -557,56 +557,31 @@ func DeleteFile(c *gin.Context) {
 	}
 
 	// Retrieve volume from transport
-	volume = models.Transport.GetVolume(volumeUUID)
-	if volume == nil {
-		c.JSON(404, responses.NewNotFoundErrorResponse(constants.TRANSPORT_VOLUME_NOT_FOUND, "Volume not found"))
-		return
-	}
+	//volume = models.Transport.GetVolume(volumeUUID)
+	//if volume == nil {
+	//	c.JSON(404, responses.NewNotFoundErrorResponse(constants.TRANSPORT_VOLUME_NOT_FOUND, "Volume not found"))
+	//	return
+	//   }
 
 	// Trigger delete process
-	errCode, err = models.Transport.DeleteVolume(volumeUUID)
-	if err != nil {
-		c.JSON(500, responses.NewOperationFailureResponse(errCode, "Volume deletion request failed: "+err.Error()))
-		return
-	}
+	//errCode, err = models.Transport.DeleteVolume(volumeUUID)
+	//if err != nil {
+	//	c.JSON(500, responses.NewOperationFailureResponse(errCode, "Volume deletion request failed: "+err.Error()))
+	//	return
+	//}
 
 	// Delete volume from database
-	volumeDBO = volume.GetVolumeDBO()
+	//volumeDBO = volume.GetVolumeDBO()
 
-	result := db.DB.DatabaseHandle.Delete(&volumeDBO)
-	if result.Error != nil {
-		c.JSON(500, responses.NewOperationFailureResponse(constants.DATABASE_ERROR, "Database operation failed: "+result.Error.Error()))
-		return
-	}
+	//result := db.DB.DatabaseHandle.Delete(&volumeDBO)
+	//if result.Error != nil {
+	//	c.JSON(500, responses.NewOperationFailureResponse(constants.DATABASE_ERROR, "Database operation failed: "+result.Error.Error()))
+	//	return
+	//}
 
 	// Return volume data
 	logger.Logger.Debug("api", "DeleteFile endpoint successful exit.")
 	c.JSON(200, responses.NewEmptySuccessResponse())
-}
-
-	// Prepare internal request data
-	bm := apicalls.BlockMetadata{
-		Ctx:              c,
-		FileUUID:         fileUUID,
-		UUID:             blockUUID,
-		Size:             0,
-		Status:           nil,
-		Content:          nil,
-		CompleteCallback: nil,
-	}
-
-	// Block the current file in the FileUploadQueue
-	err = models.Transport.FileDownloadQueue.MarkAsUsed(fileUUID)
-	if err != nil {
-		c.JSON(500, responses.NewOperationFailureResponse(constants.TRANSPORT_LOCK_FAILED, "Failed to lock file: "+err.Error()))
-		return
-	}
-
-	// Download block and return it via callback
-	errorWrapper := file.Download(&bm)
-	if errorWrapper != nil {
-		c.JSON(500, responses.NewOperationFailureResponse(constants.REMOTE_FAILED_JOB, errorWrapper.Code))
-	}
 }
 
 // InitFileDownloadRequest - handler for Init file download request

--- a/controllers/file.go
+++ b/controllers/file.go
@@ -528,9 +528,85 @@ func UpdateFile(c *gin.Context) {
 // return type:
 //   - API response with appropriate HTTP code
 func DeleteFile(c *gin.Context) {
-	// TODO: Implement deletion of the file
+	var fileUUID uuid.UUID
+	var userUUID uuid.UUID
+	var file *dbo.File
+	var errCode string
+
+	// Retrieve and validate fileUUID from param
+	fileUUID, err := uuid.Parse(c.Param("FileUUID"))
+	if err != nil {
+		c.JSON(422, responses.NewValidationErrorResponseSingle(constants.VAL_UUID_INVALID, "FileUUID", "Provided FileUUID is not a valid UUID"))
+		return
+	}
+
+	// Retrieve file from database
+	file, errCode = db.FileFromDatabase(fileUUID.String())
+	if file == nil {
+		c.JSON(404, responses.NewNotFoundErrorResponse(errCode, "File not found"))
+		return
+	}
+
+	// Retrieve userUUID from context
+	userUUID = c.MustGet("UserData").(middleware.UserData).UserUUID
+
+	// Verify that the user is owner of the file
+	if userUUID != file.UserUUID {
+		c.JSON(404, responses.NewNotFoundErrorResponse(constants.OWNER_MISMATCH, "File not found"))
+		return
+	}
+
+	// Retrieve volume from transport
+	volume = models.Transport.GetVolume(volumeUUID)
+	if volume == nil {
+		c.JSON(404, responses.NewNotFoundErrorResponse(constants.TRANSPORT_VOLUME_NOT_FOUND, "Volume not found"))
+		return
+	}
+
+	// Trigger delete process
+	errCode, err = models.Transport.DeleteVolume(volumeUUID)
+	if err != nil {
+		c.JSON(500, responses.NewOperationFailureResponse(errCode, "Volume deletion request failed: "+err.Error()))
+		return
+	}
+
+	// Delete volume from database
+	volumeDBO = volume.GetVolumeDBO()
+
+	result := db.DB.DatabaseHandle.Delete(&volumeDBO)
+	if result.Error != nil {
+		c.JSON(500, responses.NewOperationFailureResponse(constants.DATABASE_ERROR, "Database operation failed: "+result.Error.Error()))
+		return
+	}
+
+	// Return volume data
 	logger.Logger.Debug("api", "DeleteFile endpoint successful exit.")
 	c.JSON(200, responses.NewEmptySuccessResponse())
+}
+
+	// Prepare internal request data
+	bm := apicalls.BlockMetadata{
+		Ctx:              c,
+		FileUUID:         fileUUID,
+		UUID:             blockUUID,
+		Size:             0,
+		Status:           nil,
+		Content:          nil,
+		CompleteCallback: nil,
+	}
+
+	// Block the current file in the FileUploadQueue
+	err = models.Transport.FileDownloadQueue.MarkAsUsed(fileUUID)
+	if err != nil {
+		c.JSON(500, responses.NewOperationFailureResponse(constants.TRANSPORT_LOCK_FAILED, "Failed to lock file: "+err.Error()))
+		return
+	}
+
+	// Download block and return it via callback
+	errorWrapper := file.Download(&bm)
+	if errorWrapper != nil {
+		c.JSON(500, responses.NewOperationFailureResponse(constants.REMOTE_FAILED_JOB, errorWrapper.Code))
+	}
 }
 
 // InitFileDownloadRequest - handler for Init file download request

--- a/controllers/volume.go
+++ b/controllers/volume.go
@@ -243,7 +243,7 @@ func DeleteVolume(c *gin.Context) {
 	errCode, err = models.Transport.DeleteVolume(volumeUUID)
 	if err != nil {
 		logger.Logger.Error("api", "Could not delete the volume: ", volumeUUID.String())
-		c.JSON(500, responses.NewOperationFailureResponse(errCode, "Deletion request failed: "+err.Error()))
+		c.JSON(500, responses.NewOperationFailureResponse(errCode, "Volume deletion request failed: "+err.Error()))
 		return
 	}
 

--- a/db/dbHelpers.go
+++ b/db/dbHelpers.go
@@ -111,6 +111,20 @@ func IsVolumeEmpty(uuid uuid.UUID) (bool, error) {
 	return blockCount == 0, err
 }
 
+// IsDirectoryEmpty - verify whether directory is empty
+//
+// params:
+//   - uuid string: UUID of the directory to check
+//
+// return type:
+//   - bool: true if directory is empty, false otherwise
+//   - error: database operation error
+func IsDirectoryEmpty(uuid uuid.UUID) (bool, error) {
+	var fileCount int64
+	err := DB.DatabaseHandle.Model(&dbo.File{}).Where("root_uuid = ?", uuid).Count(&fileCount).Error
+	return fileCount == 0, err
+}
+
 // ValidateRootDirectory - verify whether provided root is valid
 //
 // This function verifies whether provided root entity is a valid root.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/smartystreets/goconvey v1.7.2
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	google.golang.org/api v0.94.0
 	gorm.io/driver/mysql v1.3.6
 	gorm.io/gorm v1.23.8

--- a/go.sum
+++ b/go.sum
@@ -419,6 +419,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/models/disk.go
+++ b/models/disk.go
@@ -20,7 +20,6 @@ var DiskTypesRegistry map[int]func() Disk = make(map[int]func() Disk)
 type Disk interface {
 	Upload(bm *apicalls.BlockMetadata) *apicalls.ErrorWrapper
 	Download(bm *apicalls.BlockMetadata) *apicalls.ErrorWrapper
-	Rename(bm *apicalls.BlockMetadata) *apicalls.ErrorWrapper
 	Remove(bm *apicalls.BlockMetadata) *apicalls.ErrorWrapper
 
 	SetUUID(uuid.UUID)
@@ -48,8 +47,6 @@ type Disk interface {
 	UpdateUsedSpace(change int64)
 
 	GetDiskDBO(userUUID uuid.UUID, providerUUID uuid.UUID, volumeUUID uuid.UUID) dbo.Disk
-
-	Delete() (string, error)
 }
 
 type CreateDiskMetadata struct {

--- a/models/disk/AbstractDisk/AbstractDisk.go
+++ b/models/disk/AbstractDisk/AbstractDisk.go
@@ -2,7 +2,6 @@ package AbstractDisk
 
 import (
 	"dcfs/apicalls"
-	"dcfs/constants"
 	"dcfs/db"
 	"dcfs/db/dbo"
 	"dcfs/models"
@@ -163,10 +162,4 @@ func (d *AbstractDisk) GetProvider(providerType int) uuid.UUID {
 	}
 
 	return provider.UUID
-}
-
-func (d *AbstractDisk) Delete() (string, error) {
-	// TO DO: deletion process worker
-	logger.Logger.Debug("disk", "Deleting disk: "+d.UUID.String())
-	return constants.SUCCESS, nil
 }

--- a/models/disk/FTPDisk/FTPDisk.go
+++ b/models/disk/FTPDisk/FTPDisk.go
@@ -55,7 +55,7 @@ func (d *FTPDisk) Upload(blockMetadata *apicalls.BlockMetadata) *apicalls.ErrorW
 }
 
 func (d *FTPDisk) Download(blockMetadata *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
-	// Download remote file
+	// Authenticate
 	var _client interface{} = d.GetCredentials().Authenticate(nil)
 	if _client == nil {
 		logger.Logger.Error("disk", "Could not connect to the remote server.")
@@ -64,6 +64,7 @@ func (d *FTPDisk) Download(blockMetadata *apicalls.BlockMetadata) *apicalls.Erro
 
 	var client *ftp.ServerConn = _client.(*ftp.ServerConn)
 
+	// Generate remote path
 	_p := d.abstractDisk.Credentials.GetPath()
 	downloadPath := fmt.Sprintf("%s/%s", _p, blockMetadata.UUID.String())
 	if _p == "/" {
@@ -74,13 +75,14 @@ func (d *FTPDisk) Download(blockMetadata *apicalls.BlockMetadata) *apicalls.Erro
 
 	logger.Logger.Debug("disk", "Established a download path: ", downloadPath, " for the block: ", blockMetadata.UUID.String(), ".")
 
+	// Download file from server
 	reader, err := client.Retr(downloadPath)
 	if err != nil {
 		logger.Logger.Error("disk", "Cannot open the remote file, got an error: ", err.Error())
 		return apicalls.CreateErrorWrapper(constants.REMOTE_BAD_FILE, "cannot open remote file:", err.Error())
 	}
-	//defer reader.Close()
 
+	// Load file content
 	buff, err := io.ReadAll(reader)
 	if err != nil {
 		logger.Logger.Error("disk", "Cannot open the remote file, got an error: ", err.Error())
@@ -94,12 +96,32 @@ func (d *FTPDisk) Download(blockMetadata *apicalls.BlockMetadata) *apicalls.Erro
 	return nil
 }
 
-func (d *FTPDisk) Rename(blockMetadata *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
-	panic("Unimplemented")
-}
-
 func (d *FTPDisk) Remove(blockMetadata *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
-	panic("Unimplemented")
+	// Authenticate
+	var _client interface{} = d.GetCredentials().Authenticate(nil)
+	if _client == nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_CANNOT_AUTHENTICATE, "could not connect to the remote server")
+	}
+
+	var client *ftp.ServerConn = _client.(*ftp.ServerConn)
+
+	// Generate remote path
+	_p := d.abstractDisk.Credentials.GetPath()
+	downloadPath := fmt.Sprintf("%s/%s", _p, blockMetadata.UUID.String())
+	if _p == "/" {
+		downloadPath = fmt.Sprintf("%s%s", _p, blockMetadata.UUID.String())
+	} else if _p == "" {
+		downloadPath = blockMetadata.UUID.String()
+	}
+
+	// Delete file from server
+	err := client.Delete(downloadPath)
+	if err != nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Cannot remove remote file:", err.Error())
+	}
+
+	blockMetadata.CompleteCallback(blockMetadata.FileUUID, blockMetadata.Status)
+	return nil
 }
 
 func (d *FTPDisk) SetUUID(uuid uuid.UUID) {
@@ -148,10 +170,6 @@ func (d *FTPDisk) GetCreationTime() time.Time {
 
 func (d *FTPDisk) GetProviderUUID() uuid.UUID {
 	return d.abstractDisk.GetProvider(constants.PROVIDER_TYPE_FTP)
-}
-
-func (d *FTPDisk) Delete() (string, error) {
-	return d.abstractDisk.Delete()
 }
 
 func (d *FTPDisk) GetProviderSpace() (uint64, uint64, string) {

--- a/models/disk/GDriveDisk/gdriveDisk.go
+++ b/models/disk/GDriveDisk/gdriveDisk.go
@@ -110,12 +110,40 @@ func (d *GDriveDisk) Download(blockMetadata *apicalls.BlockMetadata) *apicalls.E
 	return nil
 }
 
-func (d *GDriveDisk) Rename(bm *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
-	panic("unimplemented")
-}
-
 func (d *GDriveDisk) Remove(bm *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
-	panic("unimplemented")
+	var cred *credentials.OauthCredentials = d.GetCredentials().(*credentials.OauthCredentials)
+	var client *http.Client = cred.Authenticate(&apicalls.CredentialsAuthenticateMetadata{Ctx: bm.Ctx, Config: d.GetConfig(), DiskUUID: d.GetUUID()}).(*http.Client)
+	var fileDelete *drive.FilesDeleteCall
+	var err error
+
+	srv, err := drive.NewService(bm.Ctx, option.WithHTTPClient(client))
+	if err != nil {
+		log.Printf("Unable to retrieve Drive client: %v", err)
+		return apicalls.CreateErrorWrapper(constants.REMOTE_CLIENT_UNAVAILABLE, "Unable to retrieve Drive client:", err.Error())
+	}
+
+	files, err := srv.Files.
+		List().
+		Q(fmt.Sprintf("name = '%s'", bm.UUID.String())).
+		Do()
+	if err != nil {
+		log.Printf("unable to retreve files from gdrive: %s", err.Error())
+		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Unable to retrieve Drive client:", err.Error())
+	}
+
+	if len(files.Files) == 0 {
+		log.Printf("file with the given blockUUID: %s not found on gdrive", bm.UUID.String())
+		return apicalls.CreateErrorWrapper(constants.REMOTE_BAD_FILE, "can't find the file with the given blockUUID: %s", bm.UUID.String())
+	}
+
+	fileDelete = srv.Files.Delete(files.Files[0].Id)
+	err = fileDelete.Do()
+	if err != nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Failed to remove block:", bm.UUID.String(), "with err:", err.Error())
+	}
+
+	bm.CompleteCallback(bm.FileUUID, bm.Status)
+	return nil
 }
 
 func (d *GDriveDisk) SetUUID(uuid uuid.UUID) {
@@ -221,10 +249,6 @@ func (d *GDriveDisk) UpdateUsedSpace(change int64) {
 
 func (d *GDriveDisk) GetDiskDBO(userUUID uuid.UUID, providerUUID uuid.UUID, volumeUUID uuid.UUID) dbo.Disk {
 	return d.abstractDisk.GetDiskDBO(userUUID, providerUUID, volumeUUID)
-}
-
-func (d *GDriveDisk) Delete() (string, error) {
-	return d.abstractDisk.Delete()
 }
 
 /* Mandatory OAuthDisk interface methods */

--- a/models/disk/OneDriveDisk/OneDriveDisk.go
+++ b/models/disk/OneDriveDisk/OneDriveDisk.go
@@ -241,17 +241,7 @@ func (d *OneDriveDisk) Remove(blockMetadata *apicalls.BlockMetadata) *apicalls.E
 		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Could not find file")
 	}
 
-	item, err := oneDriveClient.DriveItems.Get(blockMetadata.Ctx, response.Value[0].Id)
-	if err != nil {
-		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Could not retrieve file data:", err.Error())
-	}
-
-	removeReq, err := oneDriveClient.NewRequest("DELETE", item.DownloadURL, nil)
-	if err != nil {
-		return apicalls.CreateErrorWrapper(constants.REMOTE_BAD_REQUEST, "Could not create a file remove request:", err.Error())
-	}
-
-	_, err = client.Do(removeReq.WithContext(blockMetadata.Ctx))
+	err = oneDriveClient.DriveItems.Delete(blockMetadata.Ctx, "", response.Value[0].Id)
 	if err != nil {
 		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Could not remove file:", err.Error())
 	}

--- a/models/disk/OneDriveDisk/OneDriveDisk.go
+++ b/models/disk/OneDriveDisk/OneDriveDisk.go
@@ -212,12 +212,52 @@ func (d *OneDriveDisk) Download(blockMetadata *apicalls.BlockMetadata) *apicalls
 	return nil
 }
 
-func (d *OneDriveDisk) Rename(blockMetadata *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
-	panic("unimplemented")
-}
-
 func (d *OneDriveDisk) Remove(blockMetadata *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
-	panic("unimplemented")
+	var _client interface{} = d.GetCredentials().Authenticate(&apicalls.CredentialsAuthenticateMetadata{Ctx: blockMetadata.Ctx, Config: d.GetConfig(), DiskUUID: d.GetUUID()})
+	if _client == nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_CANNOT_AUTHENTICATE, "could not connect to the remote server")
+	}
+
+	var client *http.Client = _client.(*http.Client)
+	oneDriveClient := onedrive.NewClient(client)
+	var searchReqUrl string = "me/drive/root/search(q='" + url.PathEscape(blockMetadata.UUID.String()) + "')?select=id"
+
+	req, err := oneDriveClient.NewRequest("GET", searchReqUrl, nil)
+	if err != nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_BAD_REQUEST, "Could not create a file search request:", err.Error())
+	}
+
+	var response oneDriveSearchResponse = oneDriveSearchResponse{}
+	err = oneDriveClient.Do(blockMetadata.Ctx, req, false, &response)
+	if err != nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Could not find file:", err.Error())
+	}
+
+	if len(response.Value) > 1 {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Block hierarchy corrupted")
+	}
+
+	if len(response.Value) == 0 {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Could not find file")
+	}
+
+	item, err := oneDriveClient.DriveItems.Get(blockMetadata.Ctx, response.Value[0].Id)
+	if err != nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Could not retrieve file data:", err.Error())
+	}
+
+	removeReq, err := oneDriveClient.NewRequest("DELETE", item.DownloadURL, nil)
+	if err != nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_BAD_REQUEST, "Could not create a file remove request:", err.Error())
+	}
+
+	_, err = client.Do(removeReq.WithContext(blockMetadata.Ctx))
+	if err != nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Could not remove file:", err.Error())
+	}
+
+	blockMetadata.CompleteCallback(blockMetadata.FileUUID, blockMetadata.Status)
+	return nil
 }
 
 func (d *OneDriveDisk) SetUUID(uuid uuid.UUID) {
@@ -320,10 +360,6 @@ func (d *OneDriveDisk) UpdateUsedSpace(change int64) {
 
 func (d *OneDriveDisk) GetDiskDBO(userUUID uuid.UUID, providerUUID uuid.UUID, volumeUUID uuid.UUID) dbo.Disk {
 	return d.abstractDisk.GetDiskDBO(userUUID, providerUUID, volumeUUID)
-}
-
-func (d *OneDriveDisk) Delete() (string, error) {
-	return d.abstractDisk.Delete()
 }
 
 /* Mandatory OAuthDisk interface implementations */

--- a/models/disk/SFTPDisk/SFTPDisk.go
+++ b/models/disk/SFTPDisk/SFTPDisk.go
@@ -100,6 +100,7 @@ func (d *SFTPDisk) Download(blockMetadata *apicalls.BlockMetadata) *apicalls.Err
 func (d *SFTPDisk) Remove(blockMetadata *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
 	var _client interface{} = d.GetCredentials().Authenticate(nil)
 	if _client == nil {
+		logger.Logger.Error("disk", "Cannot connect to the remote server.")
 		return apicalls.CreateErrorWrapper(constants.REMOTE_CANNOT_AUTHENTICATE, "Cannot connect to the remote server")
 	}
 
@@ -111,10 +112,13 @@ func (d *SFTPDisk) Remove(blockMetadata *apicalls.BlockMetadata) *apicalls.Error
 	// Remove remote file
 	err := client.Remove(downloadPath)
 	if err != nil {
-		return apicalls.CreateErrorWrapper(constants.REMOTE_BAD_FILE, "Cannot remove remote file:", downloadPath, err.Error())
+		logger.Logger.Error("disk", "Cannot remove the remote file: ", err.Error())
+		return apicalls.CreateErrorWrapper(constants.REMOTE_FAILED_JOB, "Cannot remove remote file:", err.Error())
 	}
 
 	blockMetadata.CompleteCallback(blockMetadata.FileUUID, blockMetadata.Status)
+
+	logger.Logger.Debug("disk", "Successfully removed the block: ", blockMetadata.UUID.String(), ".")
 	return nil
 }
 

--- a/models/disk/SFTPDisk/SFTPDisk.go
+++ b/models/disk/SFTPDisk/SFTPDisk.go
@@ -111,7 +111,7 @@ func (d *SFTPDisk) Remove(blockMetadata *apicalls.BlockMetadata) *apicalls.Error
 	// Remove remote file
 	err := client.Remove(downloadPath)
 	if err != nil {
-		return apicalls.CreateErrorWrapper(constants.REMOTE_BAD_FILE, "Cannot remove remote file:", err.Error())
+		return apicalls.CreateErrorWrapper(constants.REMOTE_BAD_FILE, "Cannot remove remote file:", downloadPath, err.Error())
 	}
 
 	blockMetadata.CompleteCallback(blockMetadata.FileUUID, blockMetadata.Status)

--- a/models/disk/SFTPDisk/SFTPDisk.go
+++ b/models/disk/SFTPDisk/SFTPDisk.go
@@ -97,12 +97,25 @@ func (d *SFTPDisk) Download(blockMetadata *apicalls.BlockMetadata) *apicalls.Err
 	return nil
 }
 
-func (d *SFTPDisk) Rename(blockMetadata *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
-	panic("Unimplemented")
-}
-
 func (d *SFTPDisk) Remove(blockMetadata *apicalls.BlockMetadata) *apicalls.ErrorWrapper {
-	panic("Unimplemented")
+	var _client interface{} = d.GetCredentials().Authenticate(nil)
+	if _client == nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_CANNOT_AUTHENTICATE, "Cannot connect to the remote server")
+	}
+
+	var client *sftp.Client = _client.(*sftp.Client)
+	defer client.Close()
+
+	downloadPath := blockMetadata.UUID.String()
+
+	// Remove remote file
+	err := client.Remove(downloadPath)
+	if err != nil {
+		return apicalls.CreateErrorWrapper(constants.REMOTE_BAD_FILE, "Cannot remove remote file:", err.Error())
+	}
+
+	blockMetadata.CompleteCallback(blockMetadata.FileUUID, blockMetadata.Status)
+	return nil
 }
 
 func (d *SFTPDisk) SetVolume(volume *models.Volume) {
@@ -155,10 +168,6 @@ func (d *SFTPDisk) GetProviderUUID() uuid.UUID {
 
 func (d *SFTPDisk) GetDiskDBO(userUUID uuid.UUID, providerUUID uuid.UUID, volumeUUID uuid.UUID) dbo.Disk {
 	return d.abstractDisk.GetDiskDBO(userUUID, providerUUID, volumeUUID)
-}
-
-func (d *SFTPDisk) Delete() (string, error) {
-	return d.abstractDisk.Delete()
 }
 
 func (d *SFTPDisk) GetProviderSpace() (uint64, uint64, string) {

--- a/models/transport.go
+++ b/models/transport.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"strconv"
 	"golang.org/x/sync/errgroup"
+	"log"
 	"net/http/httptest"
 	"sync"
 	"time"
@@ -341,21 +342,26 @@ func (transport *transport) DeleteDisk(disk Disk, volume *Volume, relocate bool)
 	}
 
 	// Delete blocks from disk
-	waitGroup, _ := errgroup.WithContext(context.Background())
+	var waitGroup sync.WaitGroup
+	var taskCompleted bool = true
+
+	waitGroup.Add(len(blocks))
 
 	for _, block := range blocks {
-		waitGroup.Go(func() error {
+		go func(block dbo.Block) {
+			log.Println("Deleting block", block.UUID)
+			defer waitGroup.Done()
+
 			// Prepare test context
 			writer := httptest.NewRecorder()
 			_ctx, _ := gin.CreateTestContext(writer)
 
 			// Prepare apicall metadata
 			var status int
-			//var content []uint8 = make([]uint8, block.Size)
 			var blockMetadata *apicalls.BlockMetadata = new(apicalls.BlockMetadata)
 			blockMetadata.Ctx = _ctx
 			blockMetadata.FileUUID = block.FileUUID
-			blockMetadata.Content = nil //&content
+			blockMetadata.Content = nil
 			blockMetadata.UUID = block.UUID
 			blockMetadata.Size = int64(block.Size)
 			blockMetadata.Status = &status
@@ -367,15 +373,23 @@ func (transport *transport) DeleteDisk(disk Disk, volume *Volume, relocate bool)
 
 			result = disk.Remove(blockMetadata)
 			if result != nil {
-				return result.Error
+				taskCompleted = false
+				return
 			}
 
-			return nil
-		})
+			// Remove block from database
+			dBErr := db.DB.DatabaseHandle.Delete(&block).Error
+			if dBErr != nil {
+				taskCompleted = false
+				return
+			}
+
+			return
+		}(block)
 	}
-	err := waitGroup.Wait()
-	if err != nil {
-		return constants.OPERATION_FAILED, err
+	waitGroup.Wait()
+	if taskCompleted != true {
+		return constants.OPERATION_FAILED, errors.New("Failed to delete blocks from disk")
 	}
 
 	// Remove disk from database

--- a/models/transport.go
+++ b/models/transport.go
@@ -11,10 +11,10 @@ import (
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"strconv"
 	"golang.org/x/sync/errgroup"
 	"log"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -290,8 +290,12 @@ func (transport *transport) FindEnqueuedVolume(volumeUUID uuid.UUID) *Volume {
 
 // DeleteVolume - deletes the given volume, its disks and removes it from the ActiveVolumes array.
 //
-// fields:
-//   - volumeUUID
+// params:
+//   - volumeUUID uuid.UUID: uuid of the volume to be deleted
+//
+// return type:
+//   - errorCode string: constant.SUCCESS if password match, error code otherwise
+//   - error error: nil if operation was successful, error otherwise
 func (transport *transport) DeleteVolume(volumeUUID uuid.UUID) (string, error) {
 	var volume *Volume
 
@@ -329,6 +333,16 @@ func (transport *transport) DeleteVolume(volumeUUID uuid.UUID) (string, error) {
 	return constants.SUCCESS, nil
 }
 
+// DeleteDisk - deletes the given disk, its contents (blocks) and disattaches it from the volume.
+//
+// params:
+//   - disk models.Disk: target disk to be deleted
+//   - volume *models.Volume: volume to which the disk belongs
+//   - deletionType constants.DeletionType: type of operation (deletion of blocks or relocation to another disk)
+//
+// return type:
+//   - errorCode string: constant.SUCCESS if password match, error code otherwise
+//   - error error: nil if operation was successful, error otherwise
 func (transport *transport) DeleteDisk(disk Disk, volume *Volume, relocate bool) (string, error) {
 	var blocks []dbo.Block
 
@@ -401,6 +415,15 @@ func (transport *transport) DeleteDisk(disk Disk, volume *Volume, relocate bool)
 	return constants.SUCCESS, nil
 }
 
+// DeleteFile - deletes the given file and its contents blocks.
+//
+// params:
+//   - file models.File: target file to be deleted
+//   - volume *models.Volume: volume to which the disk belongs
+//
+// return type:
+//   - errorCode string: constant.SUCCESS if password match, error code otherwise
+//   - error error: nil if operation was successful, error otherwise
 func (transport *transport) DeleteFile(file File, volume *Volume) (string, error) {
 	// Retrieve blocks of file
 	var blocks = file.GetBlocks()

--- a/models/transport.go
+++ b/models/transport.go
@@ -332,9 +332,6 @@ func (transport *transport) DeleteVolume(volumeUUID uuid.UUID) (string, error) {
 func (transport *transport) DeleteDisk(disk Disk, volume *Volume, relocate bool) (string, error) {
 	var blocks []dbo.Block
 
-	// Disattach disk from volume
-	volume.DeleteDisk(disk.GetUUID())
-
 	// Retrieve list of blocks on disk
 	dBErr := db.DB.DatabaseHandle.Where("disk_uuid = ?", disk.GetUUID()).Find(&blocks).Error
 	if dBErr != nil {
@@ -398,8 +395,8 @@ func (transport *transport) DeleteDisk(disk Disk, volume *Volume, relocate bool)
 		return constants.DATABASE_ERROR, dbErr
 	}
 
-	// Refresh volume partitioner after disk list change
-	go volume.RefreshPartitioner()
+	// Disattach disk from volume
+	volume.DeleteDisk(disk.GetUUID())
 
 	return constants.SUCCESS, nil
 }

--- a/models/transport.go
+++ b/models/transport.go
@@ -1,14 +1,19 @@
 package models
 
 import (
+	"context"
+	"dcfs/apicalls"
 	"dcfs/constants"
 	"dcfs/db"
 	"dcfs/db/dbo"
 	"dcfs/util/logger"
 	"errors"
 	"fmt"
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"strconv"
+	"golang.org/x/sync/errgroup"
+	"net/http/httptest"
 	"sync"
 	"time"
 )
@@ -282,14 +287,11 @@ func (transport *transport) FindEnqueuedVolume(volumeUUID uuid.UUID) *Volume {
 	return nil
 }
 
-// DeleteVolume - deletes the given volume from the ActiveVolumes array.
+// DeleteVolume - deletes the given volume, its disks and removes it from the ActiveVolumes array.
 //
 // fields:
 //   - volumeUUID
 func (transport *transport) DeleteVolume(volumeUUID uuid.UUID) (string, error) {
-	// TODO: Implement deletion process worker
-	var errCode string
-	var err error
 	var volume *Volume
 
 	// Retrieve volume from transport
@@ -300,18 +302,91 @@ func (transport *transport) DeleteVolume(volumeUUID uuid.UUID) (string, error) {
 	}
 
 	// Trigger delete process in all disks assigned to this volume
+	waitGroup, _ := errgroup.WithContext(context.Background())
+
 	for _, disk := range volume.disks {
-		errCode, err = disk.Delete()
-		if err != nil {
-			logger.Logger.Error("transport", "Could not delete the disk: ", disk.GetUUID().String(), ".")
-			return errCode, err
-		}
+		waitGroup.Go(func() error {
+			errCode, err := transport.DeleteDisk(disk, volume, constants.DELETION)
+			if errCode != constants.SUCCESS {
+				logger.Logger.Error("transport", "Could not delete the disk: ", disk.GetUUID().String(), ".")
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	err := waitGroup.Wait()
+	if err != nil {
+		return constants.OPERATION_FAILED, err
 	}
 
 	// Remove volume from transport
 	transport.ActiveVolumes.RemoveEnqueuedInstance(volumeUUID)
 
 	logger.Logger.Debug("transport", "Successfully removed the volume: ", volumeUUID.String(), " from Transport.")
+	return constants.SUCCESS, nil
+}
+
+func (transport *transport) DeleteDisk(disk Disk, volume *Volume, relocate bool) (string, error) {
+	var blocks []dbo.Block
+
+	// Disattach disk from volume
+	volume.DeleteDisk(disk.GetUUID())
+
+	// Retrieve list of blocks on disk
+	dBErr := db.DB.DatabaseHandle.Where("disk_uuid = ?", disk.GetUUID()).Find(&blocks).Error
+	if dBErr != nil {
+		return constants.DATABASE_ERROR, dBErr
+	}
+
+	// Delete blocks from disk
+	waitGroup, _ := errgroup.WithContext(context.Background())
+
+	for _, block := range blocks {
+		waitGroup.Go(func() error {
+			// Prepare test context
+			writer := httptest.NewRecorder()
+			_ctx, _ := gin.CreateTestContext(writer)
+
+			// Prepare apicall metadata
+			var status int
+			//var content []uint8 = make([]uint8, block.Size)
+			var blockMetadata *apicalls.BlockMetadata = new(apicalls.BlockMetadata)
+			blockMetadata.Ctx = _ctx
+			blockMetadata.FileUUID = block.FileUUID
+			blockMetadata.Content = nil //&content
+			blockMetadata.UUID = block.UUID
+			blockMetadata.Size = int64(block.Size)
+			blockMetadata.Status = &status
+			blockMetadata.CompleteCallback = func(UUID uuid.UUID, status *int) {
+			}
+
+			// Delete block from current disk
+			var result *apicalls.ErrorWrapper
+
+			result = disk.Remove(blockMetadata)
+			if result != nil {
+				return result.Error
+			}
+
+			return nil
+		})
+	}
+	err := waitGroup.Wait()
+	if err != nil {
+		return constants.OPERATION_FAILED, err
+	}
+
+	// Remove disk from database
+	dbErr := db.DB.DatabaseHandle.Delete(&dbo.Disk{}, disk.GetUUID()).Error
+	if dbErr != nil {
+		return constants.DATABASE_ERROR, dbErr
+	}
+
+	// Refresh volume partitioner after disk list change
+	go volume.RefreshPartitioner()
+
 	return constants.SUCCESS, nil
 }
 


### PR DESCRIPTION
Implemented deletion operation for Volumes, Disks and Files.

Deleting File will delete the file and all the blocks from remote disks. Directory can be deleted if it's empty.

Deleting Disk will delete all blocks which are located on the target disk - currently no file data will be deleted and files splitted between target and other drives will be corrupted (eventually deleting single disk will result in relocation of blocks to another disk from the same volume, so stored files will not be affected).

Deleting Volume will delete the volume, all associated drives and files stored on target volume.