### PR TITLE
[DCFS-156] getDisks and getDisk refactor

### DIFF
--- a/apicalls/credentialsAuthenticateInterface.go
+++ b/apicalls/credentialsAuthenticateInterface.go
@@ -1,13 +1,13 @@
 package apicalls
 
 import (
-	"github.com/gin-gonic/gin"
+	"context"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 )
 
 type CredentialsAuthenticateMetadata struct {
-	Ctx      *gin.Context
+	Ctx      context.Context
 	Config   *oauth2.Config
 	DiskUUID uuid.UUID
 }

--- a/constants/completionCodes.go
+++ b/constants/completionCodes.go
@@ -15,6 +15,7 @@ const (
 	VAL_PROVIDER_NOT_SUPPORTED = "VAL-020"
 	VAL_SIZE_INVALID           = "VAL-030"
 	VAL_QUOTA_EXCEEDED         = "VAL-031"
+	VAL_CREDENTIALS_INVALID    = "VAL=040"
 
 	// Database errors
 	DATABASE_ERROR            = "DB-001"

--- a/controllers/disk.go
+++ b/controllers/disk.go
@@ -225,7 +225,8 @@ func DiskOAuth(c *gin.Context) {
 	logger.Logger.Debug("api", "The disk space has been set to: ", strconv.FormatUint(disk.GetTotalSpace(), 10), ".")
 
 	// Save disk credentials to database
-	result := db.DB.DatabaseHandle.Save(disk.GetDiskDBO(userUUID, _disk.ProviderUUID, _disk.VolumeUUID))
+	_diskDBO := disk.GetDiskDBO(userUUID, _disk.ProviderUUID, _disk.VolumeUUID)
+	result := db.DB.DatabaseHandle.Save(&_diskDBO)
 	if result.Error != nil {
 		logger.Logger.Error("api", "Could not save the disk: ", _diskUUID, " in the db.")
 		c.JSON(500, responses.NewOperationFailureResponse(constants.DATABASE_ERROR, "Database operation failed: "+result.Error.Error()))

--- a/controllers/disk.go
+++ b/controllers/disk.go
@@ -305,7 +305,7 @@ func GetDisk(c *gin.Context) {
 	logger.Logger.Debug("api", "The disk capacity is: ", strconv.FormatUint(_disk.FreeSpace, 10), "/", strconv.FormatUint(_disk.TotalSpace, 10), ".")
 
 	logger.Logger.Debug("api", "GetDisk endpoint successful exit.")
-	c.JSON(200, responses.NewSuccessResponse(diskModel.GetResponse(&_disk)))
+	c.JSON(200, responses.NewSuccessResponse(diskModel.GetResponse(&_disk, c)))
 }
 
 // UpdateDisk - handler for Update disk details request
@@ -543,7 +543,7 @@ func GetDisks(c *gin.Context) {
 		disk := volume.GetDisk(_disk.UUID)
 
 		// Append disk to the list
-		disks = append(disks, disk.GetResponse(&_disk))
+		disks = append(disks, disk.GetResponse(&_disk, c))
 	}
 
 	// Prepare pagination

--- a/controllers/disk.go
+++ b/controllers/disk.go
@@ -107,6 +107,13 @@ func CreateDisk(c *gin.Context) {
 			_disk.TotalSpace = totalSpace
 			logger.Logger.Debug("api", "Set the disk total space to: ", strconv.FormatUint(totalSpace, 10))
 		}
+
+		// check if the credentials are correct
+		if !disk.GetReadiness().IsReadyForce(c) {
+			logger.Logger.Error("api", "Credentials for a new disk: ", requestBody.Credentials.ToString(), " were incorrect.")
+			c.JSON(500, responses.NewOperationFailureResponse(constants.VAL_CREDENTIALS_INVALID, "Provided credentials were incorrect"))
+			return
+		}
 	}
 
 	// Find virtual disk uuid for new disk
@@ -392,6 +399,11 @@ func UpdateDisk(c *gin.Context) {
 		}
 
 		disk.CreateCredentials(cred)
+		if !disk.GetReadiness().IsReadyForce(c) {
+			logger.Logger.Error("api", "The provided credentials: ", body.Credentials.ToString(), " are invalid.")
+			c.JSON(405, responses.NewOperationFailureResponse(constants.VAL_CREDENTIALS_INVALID, "Provided credentials are invalid"))
+			return
+		}
 		logger.Logger.Debug("api", "Updated the credentials of the disk with the uuid: ", _diskUUID)
 	}
 

--- a/controllers/file.go
+++ b/controllers/file.go
@@ -284,7 +284,7 @@ func InitFileUploadRequest(c *gin.Context) {
 	}
 
 	// Verify that the volume is ready to handle file operations
-	if !volume.IsReady() {
+	if !volume.IsReady(c) {
 		logger.Logger.Error("api", "Attempted to execute file operations on a not ready volume: ", volumeUUID.String())
 		c.JSON(500, responses.NewOperationFailureResponse(constants.TRANSPORT_VOLUME_NOT_READY, "Selected volume is not ready. Please make sure that its disks are configured properly."))
 		return

--- a/controllers/file.go
+++ b/controllers/file.go
@@ -284,7 +284,7 @@ func InitFileUploadRequest(c *gin.Context) {
 	}
 
 	// Verify that the volume is ready to handle file operations
-	if !volume.IsReady(c) {
+	if !volume.IsReady(c, true) {
 		logger.Logger.Error("api", "Attempted to execute file operations on a not ready volume: ", volumeUUID.String())
 		c.JSON(500, responses.NewOperationFailureResponse(constants.TRANSPORT_VOLUME_NOT_READY, "Selected volume is not ready. Please make sure that its disks are configured properly."))
 		return

--- a/controllers/volume.go
+++ b/controllers/volume.go
@@ -107,7 +107,7 @@ func GetVolume(c *gin.Context) {
 	logger.Logger.Debug("api", "GetVolume endpoint successful exit.")
 	c.JSON(200, responses.NewVolumeListSuccessResponse(&responses.VolumeResponse{
 		Volume:  *volume,
-		IsReady: v.IsReady(c),
+		IsReady: v.IsReady(c, false),
 	}))
 }
 
@@ -311,7 +311,7 @@ func GetVolumes(c *gin.Context) {
 
 		volumesPagination = append(volumesPagination, responses.VolumeResponse{
 			Volume:  _v,
-			IsReady: v.IsReady(c),
+			IsReady: v.IsReady(c, false),
 		})
 	}
 

--- a/controllers/volume.go
+++ b/controllers/volume.go
@@ -107,7 +107,7 @@ func GetVolume(c *gin.Context) {
 	logger.Logger.Debug("api", "GetVolume endpoint successful exit.")
 	c.JSON(200, responses.NewVolumeListSuccessResponse(&responses.VolumeResponse{
 		Volume:  *volume,
-		IsReady: v.IsReady(),
+		IsReady: v.IsReady(c),
 	}))
 }
 
@@ -311,7 +311,7 @@ func GetVolumes(c *gin.Context) {
 
 		volumesPagination = append(volumesPagination, responses.VolumeResponse{
 			Volume:  _v,
-			IsReady: v.IsReady(),
+			IsReady: v.IsReady(c),
 		})
 	}
 

--- a/models/disk.go
+++ b/models/disk.go
@@ -16,6 +16,7 @@ import (
 
 var RootUUID uuid.UUID
 var DiskTypesRegistry map[int]func() Disk = make(map[int]func() Disk)
+var DiskReadinessRegistry map[int]func(d Disk) DiskReadiness = make(map[int]func(d Disk) DiskReadiness)
 
 type Disk interface {
 	Upload(bm *apicalls.BlockMetadata) *apicalls.ErrorWrapper

--- a/models/disk.go
+++ b/models/disk.go
@@ -55,6 +55,13 @@ type Disk interface {
 
 	AssignDisk(disk Disk)
 	IsReady() bool
+	GetResponse(_disk *dbo.Disk) *DiskResponse
+}
+
+type DiskResponse struct {
+	dbo.Disk
+	Array   []DiskResponse `json:"array"`
+	IsReady bool           `json:"isReady"`
 }
 
 type CreateDiskMetadata struct {

--- a/models/disk.go
+++ b/models/disk.go
@@ -54,7 +54,7 @@ type Disk interface {
 	GetDiskDBO(userUUID uuid.UUID, providerUUID uuid.UUID, volumeUUID uuid.UUID) dbo.Disk
 
 	AssignDisk(disk Disk)
-	IsReady(ctx *gin.Context) bool
+	GetReadiness() DiskReadiness
 	GetResponse(_disk *dbo.Disk, ctx *gin.Context) *DiskResponse
 }
 

--- a/models/disk.go
+++ b/models/disk.go
@@ -54,8 +54,8 @@ type Disk interface {
 	GetDiskDBO(userUUID uuid.UUID, providerUUID uuid.UUID, volumeUUID uuid.UUID) dbo.Disk
 
 	AssignDisk(disk Disk)
-	IsReady() bool
-	GetResponse(_disk *dbo.Disk) *DiskResponse
+	IsReady(ctx *gin.Context) bool
+	GetResponse(_disk *dbo.Disk, ctx *gin.Context) *DiskResponse
 }
 
 type DiskResponse struct {

--- a/models/disk/AbstractDisk/AbstractDisk.go
+++ b/models/disk/AbstractDisk/AbstractDisk.go
@@ -28,6 +28,8 @@ type AbstractDisk struct {
 
 	Size      uint64
 	UsedSpace uint64
+
+	DiskReadiness models.DiskReadiness
 }
 
 /* Mandatory Disk interface implementations */
@@ -199,24 +201,15 @@ func (d *AbstractDisk) AssignDisk(disk models.Disk) {
 	panic("Not supported for real disk")
 }
 
-func (d *AbstractDisk) IsReady(ctx *gin.Context) bool {
-	// check if it is possible to connect to a disk
-	if d.GetCredentials().Authenticate(&apicalls.CredentialsAuthenticateMetadata{
-		Ctx:      ctx,
-		Config:   nil,
-		DiskUUID: d.GetUUID(),
-	}) == nil {
-		return false
-	}
-
-	return true
+func (d *AbstractDisk) GetReadiness() models.DiskReadiness {
+	return d.DiskReadiness
 }
 
 func (d *AbstractDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
 	return &models.DiskResponse{
 		Disk:    *_disk,
 		Array:   nil,
-		IsReady: d.IsReady(ctx),
+		IsReady: d.GetReadiness().IsReady(ctx),
 	}
 }
 

--- a/models/disk/AbstractDisk/AbstractDisk.go
+++ b/models/disk/AbstractDisk/AbstractDisk.go
@@ -158,6 +158,25 @@ func (d *AbstractDisk) GetDiskDBO(userUUID uuid.UUID, providerUUID uuid.UUID, vo
 		credentials = d.Credentials.ToString()
 	}
 
+	var provider dbo.Provider
+	var user dbo.User
+	var volume dbo.Volume
+
+	err := db.DB.DatabaseHandle.Where("uuid = ?", providerUUID).First(&provider).Error
+	if err != nil {
+		logger.Logger.Warning("disk", "could not fetch the provider object with uuid: ", providerUUID.String(), ".")
+	}
+
+	err = db.DB.DatabaseHandle.Where("uuid = ?", userUUID).First(&user).Error
+	if err != nil {
+		logger.Logger.Warning("disk", "could not fetch the user object with uuid: ", userUUID.String(), ".")
+	}
+
+	err = db.DB.DatabaseHandle.Where("uuid = ?", volumeUUID).First(&volume).Error
+	if err != nil {
+		logger.Logger.Warning("disk", "could not fetch the volume object with uuid: ", volumeUUID.String(), ".")
+	}
+
 	return dbo.Disk{
 		AbstractDatabaseObject: dbo.AbstractDatabaseObject{UUID: d.UUID},
 		UserUUID:               userUUID,
@@ -169,6 +188,9 @@ func (d *AbstractDisk) GetDiskDBO(userUUID uuid.UUID, providerUUID uuid.UUID, vo
 		UsedSpace:              d.UsedSpace,
 		IsVirtual:              d.IsVirtual,
 		VirtualDiskUUID:        d.VirtualDiskUUID,
+		User:                   user,
+		Volume:                 volume,
+		Provider:               provider,
 	}
 }
 

--- a/models/disk/AbstractDisk/AbstractDisk.go
+++ b/models/disk/AbstractDisk/AbstractDisk.go
@@ -204,7 +204,7 @@ func (d *AbstractDisk) IsReady(ctx *gin.Context) bool {
 	if d.GetCredentials().Authenticate(&apicalls.CredentialsAuthenticateMetadata{
 		Ctx:      ctx,
 		Config:   nil,
-		DiskUUID: uuid.UUID{},
+		DiskUUID: d.GetUUID(),
 	}) == nil {
 		return false
 	}

--- a/models/disk/AbstractDisk/AbstractDisk.go
+++ b/models/disk/AbstractDisk/AbstractDisk.go
@@ -7,6 +7,7 @@ import (
 	"dcfs/models"
 	"dcfs/models/credentials"
 	"dcfs/util/logger"
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"strconv"
 	"time"
@@ -198,15 +199,24 @@ func (d *AbstractDisk) AssignDisk(disk models.Disk) {
 	panic("Not supported for real disk")
 }
 
-func (d *AbstractDisk) IsReady() bool {
+func (d *AbstractDisk) IsReady(ctx *gin.Context) bool {
+	// check if it is possible to connect to a disk
+	if d.GetCredentials().Authenticate(&apicalls.CredentialsAuthenticateMetadata{
+		Ctx:      ctx,
+		Config:   nil,
+		DiskUUID: uuid.UUID{},
+	}) == nil {
+		return false
+	}
+
 	return true
 }
 
-func (d *AbstractDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
+func (d *AbstractDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
 	return &models.DiskResponse{
 		Disk:    *_disk,
 		Array:   nil,
-		IsReady: d.IsReady(),
+		IsReady: d.IsReady(ctx),
 	}
 }
 

--- a/models/disk/AbstractDisk/AbstractDisk.go
+++ b/models/disk/AbstractDisk/AbstractDisk.go
@@ -180,6 +180,14 @@ func (d *AbstractDisk) IsReady() bool {
 	return true
 }
 
+func (d *AbstractDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
+	return &models.DiskResponse{
+		Disk:    *_disk,
+		Array:   nil,
+		IsReady: d.IsReady(),
+	}
+}
+
 /* Additional abstract functions */
 
 func (d *AbstractDisk) GetProvider(providerType int) uuid.UUID {

--- a/models/disk/BackupDisk/BackupDisk.go
+++ b/models/disk/BackupDisk/BackupDisk.go
@@ -9,6 +9,7 @@ import (
 	"dcfs/models/disk/AbstractDisk"
 	"dcfs/util/checksum"
 	"dcfs/util/logger"
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"sync"
 	"time"
@@ -392,26 +393,28 @@ func (d *BackupDisk) AssignDisk(disk models.Disk) {
 	}
 }
 
-func (d *BackupDisk) IsReady() bool {
+func (d *BackupDisk) IsReady(ctx *gin.Context) bool {
 	if d.firstDisk == nil || d.secondDisk == nil {
 		return false
 	}
 
-	return d.firstDisk.IsReady() && d.secondDisk.IsReady()
+	return d.firstDisk.IsReady(ctx) && d.secondDisk.IsReady(ctx)
 }
 
-func (d *BackupDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
-	rsp := d.abstractDisk.GetResponse(_disk)
+func (d *BackupDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
 	arr := make([]models.DiskResponse, 0)
 
 	firstDiskDBO := d.firstDisk.GetDiskDBO(_disk.UserUUID, _disk.ProviderUUID, _disk.VolumeUUID)
 	secondDiskDBO := d.secondDisk.GetDiskDBO(_disk.UserUUID, _disk.ProviderUUID, _disk.VolumeUUID)
 
-	arr = append(arr, *d.firstDisk.GetResponse(&firstDiskDBO))
-	arr = append(arr, *d.secondDisk.GetResponse(&secondDiskDBO))
+	arr = append(arr, *d.firstDisk.GetResponse(&firstDiskDBO, ctx))
+	arr = append(arr, *d.secondDisk.GetResponse(&secondDiskDBO, ctx))
 
-	rsp.Array = arr
-	return rsp
+	return &models.DiskResponse{
+		Disk:    *_disk,
+		Array:   arr,
+		IsReady: d.IsReady(ctx),
+	}
 }
 
 func (d *BackupDisk) fixBlock(blockMetadata *apicalls.BlockMetadata, firstContents []uint8, secondContents []uint8, firstChecksum string, secondChecksum string) {

--- a/models/disk/BackupDisk/BackupDisk.go
+++ b/models/disk/BackupDisk/BackupDisk.go
@@ -400,6 +400,20 @@ func (d *BackupDisk) IsReady() bool {
 	return d.firstDisk.IsReady() && d.secondDisk.IsReady()
 }
 
+func (d *BackupDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
+	rsp := d.abstractDisk.GetResponse(_disk)
+	arr := make([]models.DiskResponse, 0)
+
+	firstDiskDBO := d.firstDisk.GetDiskDBO(_disk.UserUUID, _disk.ProviderUUID, _disk.VolumeUUID)
+	secondDiskDBO := d.secondDisk.GetDiskDBO(_disk.UserUUID, _disk.ProviderUUID, _disk.VolumeUUID)
+
+	arr = append(arr, *d.firstDisk.GetResponse(&firstDiskDBO))
+	arr = append(arr, *d.secondDisk.GetResponse(&secondDiskDBO))
+
+	rsp.Array = arr
+	return rsp
+}
+
 func (d *BackupDisk) fixBlock(blockMetadata *apicalls.BlockMetadata, firstContents []uint8, secondContents []uint8, firstChecksum string, secondChecksum string) {
 	var err *apicalls.ErrorWrapper
 	var targetDisk models.Disk

--- a/models/disk/BackupDisk/BackupDisk.go
+++ b/models/disk/BackupDisk/BackupDisk.go
@@ -393,12 +393,17 @@ func (d *BackupDisk) AssignDisk(disk models.Disk) {
 	}
 }
 
-func (d *BackupDisk) IsReady(ctx *gin.Context) bool {
-	if d.firstDisk == nil || d.secondDisk == nil {
-		return false
+func (d *BackupDisk) GetReadiness() models.DiskReadiness {
+	arr := make([]models.DiskReadiness, 0)
+
+	if d.firstDisk != nil {
+		arr = append(arr, d.firstDisk.GetReadiness())
+	}
+	if d.secondDisk != nil {
+		arr = append(arr, d.secondDisk.GetReadiness())
 	}
 
-	return d.firstDisk.IsReady(ctx) && d.secondDisk.IsReady(ctx)
+	return models.NewVirtualDiskReadiness(arr...)
 }
 
 func (d *BackupDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
@@ -413,7 +418,7 @@ func (d *BackupDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.Disk
 	return &models.DiskResponse{
 		Disk:    *_disk,
 		Array:   arr,
-		IsReady: d.IsReady(ctx),
+		IsReady: d.GetReadiness().IsReady(ctx),
 	}
 }
 

--- a/models/disk/BackupDisk/BackupDisk.go
+++ b/models/disk/BackupDisk/BackupDisk.go
@@ -404,8 +404,8 @@ func (d *BackupDisk) IsReady(ctx *gin.Context) bool {
 func (d *BackupDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
 	arr := make([]models.DiskResponse, 0)
 
-	firstDiskDBO := d.firstDisk.GetDiskDBO(_disk.UserUUID, _disk.ProviderUUID, _disk.VolumeUUID)
-	secondDiskDBO := d.secondDisk.GetDiskDBO(_disk.UserUUID, _disk.ProviderUUID, _disk.VolumeUUID)
+	firstDiskDBO := d.firstDisk.GetDiskDBO(_disk.UserUUID, d.firstDisk.GetProviderUUID(), _disk.VolumeUUID)
+	secondDiskDBO := d.secondDisk.GetDiskDBO(_disk.UserUUID, d.secondDisk.GetProviderUUID(), _disk.VolumeUUID)
 
 	arr = append(arr, *d.firstDisk.GetResponse(&firstDiskDBO, ctx))
 	arr = append(arr, *d.secondDisk.GetResponse(&secondDiskDBO, ctx))

--- a/models/disk/FTPDisk/FTPDisk.go
+++ b/models/disk/FTPDisk/FTPDisk.go
@@ -10,6 +10,7 @@ import (
 	"dcfs/models/disk/AbstractDisk"
 	"dcfs/util/logger"
 	"fmt"
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jlaffaye/ftp"
 	"io"
@@ -226,12 +227,12 @@ func (d *FTPDisk) AssignDisk(disk models.Disk) {
 	d.abstractDisk.AssignDisk(disk)
 }
 
-func (d *FTPDisk) IsReady() bool {
-	return d.abstractDisk.IsReady()
+func (d *FTPDisk) IsReady(ctx *gin.Context) bool {
+	return d.abstractDisk.IsReady(ctx)
 }
 
-func (d *FTPDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
-	return d.abstractDisk.GetResponse(_disk)
+func (d *FTPDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
+	return d.abstractDisk.GetResponse(_disk, ctx)
 }
 
 /* Factory methods */

--- a/models/disk/FTPDisk/FTPDisk.go
+++ b/models/disk/FTPDisk/FTPDisk.go
@@ -230,6 +230,10 @@ func (d *FTPDisk) IsReady() bool {
 	return d.abstractDisk.IsReady()
 }
 
+func (d *FTPDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
+	return d.abstractDisk.GetResponse(_disk)
+}
+
 /* Factory methods */
 
 func NewFTPDisk() *FTPDisk {

--- a/models/disk/GDriveDisk/gdriveDisk.go
+++ b/models/disk/GDriveDisk/gdriveDisk.go
@@ -317,6 +317,8 @@ func (d *GDriveDisk) IsReady(ctx *gin.Context) bool {
 }
 
 func (d *GDriveDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
+	_disk.Credentials = ""
+
 	return &models.DiskResponse{
 		Disk:    *_disk,
 		Array:   nil,

--- a/models/disk/GDriveDisk/gdriveDisk.go
+++ b/models/disk/GDriveDisk/gdriveDisk.go
@@ -296,6 +296,10 @@ func (d *GDriveDisk) IsReady() bool {
 	return d.abstractDisk.IsReady()
 }
 
+func (d *GDriveDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
+	return d.abstractDisk.GetResponse(_disk)
+}
+
 /* Factory methods */
 
 func NewGDriveDisk() *GDriveDisk {

--- a/models/disk/GDriveDisk/gdriveDisk.go
+++ b/models/disk/GDriveDisk/gdriveDisk.go
@@ -297,7 +297,7 @@ func (d *GDriveDisk) IsReady(ctx *gin.Context) bool {
 	client := d.GetCredentials().Authenticate(&apicalls.CredentialsAuthenticateMetadata{
 		Ctx:      ctx,
 		Config:   d.GetConfig(),
-		DiskUUID: uuid.UUID{},
+		DiskUUID: d.GetUUID(),
 	}).(*http.Client)
 
 	srv, err := drive.NewService(ctx, option.WithHTTPClient(client))

--- a/models/disk/OneDriveDisk/OneDriveDisk.go
+++ b/models/disk/OneDriveDisk/OneDriveDisk.go
@@ -2,6 +2,7 @@ package OneDriveDisk
 
 import (
 	"bytes"
+	"context"
 	"dcfs/apicalls"
 	"dcfs/constants"
 	"dcfs/db/dbo"
@@ -410,21 +411,8 @@ func (d *OneDriveDisk) AssignDisk(disk models.Disk) {
 	d.abstractDisk.AssignDisk(disk)
 }
 
-func (d *OneDriveDisk) IsReady(ctx *gin.Context) bool {
-	// check if it is possible to connect to a disk
-	client := d.GetCredentials().Authenticate(&apicalls.CredentialsAuthenticateMetadata{
-		Ctx:      ctx,
-		Config:   d.GetConfig(),
-		DiskUUID: d.GetUUID(),
-	}).(*http.Client)
-	oneDriveClient := onedrive.NewClient(client)
-
-	_, err := oneDriveClient.Drives.List(ctx)
-	if err != nil {
-		return false
-	}
-
-	return true
+func (d *OneDriveDisk) GetReadiness() models.DiskReadiness {
+	return d.abstractDisk.DiskReadiness
 }
 
 func (d *OneDriveDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
@@ -433,7 +421,7 @@ func (d *OneDriveDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.Di
 	return &models.DiskResponse{
 		Disk:    *_disk,
 		Array:   nil,
-		IsReady: d.IsReady(ctx),
+		IsReady: d.GetReadiness().IsReady(ctx),
 	}
 }
 
@@ -442,6 +430,22 @@ func (d *OneDriveDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.Di
 func NewOneDriveDisk() *OneDriveDisk {
 	var d *OneDriveDisk = new(OneDriveDisk)
 	d.abstractDisk.Disk = d
+	d.abstractDisk.DiskReadiness = models.NewRealDiskReadiness(func(ctx context.Context) bool {
+		logger.Logger.Debug("drive", "Checking readiness for OneDrive drive: ", d.GetUUID().String(), ".")
+		client := d.GetCredentials().Authenticate(&apicalls.CredentialsAuthenticateMetadata{
+			Ctx:      ctx,
+			Config:   d.GetConfig(),
+			DiskUUID: d.GetUUID(),
+		}).(*http.Client)
+		oneDriveClient := onedrive.NewClient(client)
+
+		_, err := oneDriveClient.Drives.List(ctx)
+		if err != nil {
+			return false
+		}
+
+		return true
+	}, func() bool { return models.Transport.ActiveVolumes.GetEnqueuedInstance(d.GetVolume().UUID) != nil })
 	return d
 }
 

--- a/models/disk/OneDriveDisk/OneDriveDisk.go
+++ b/models/disk/OneDriveDisk/OneDriveDisk.go
@@ -414,6 +414,10 @@ func (d *OneDriveDisk) IsReady() bool {
 	return d.abstractDisk.IsReady()
 }
 
+func (d *OneDriveDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
+	return d.abstractDisk.GetResponse(_disk)
+}
+
 /* Factory methods */
 
 func NewOneDriveDisk() *OneDriveDisk {

--- a/models/disk/OneDriveDisk/OneDriveDisk.go
+++ b/models/disk/OneDriveDisk/OneDriveDisk.go
@@ -415,7 +415,7 @@ func (d *OneDriveDisk) IsReady(ctx *gin.Context) bool {
 	client := d.GetCredentials().Authenticate(&apicalls.CredentialsAuthenticateMetadata{
 		Ctx:      ctx,
 		Config:   d.GetConfig(),
-		DiskUUID: uuid.UUID{},
+		DiskUUID: d.GetUUID(),
 	}).(*http.Client)
 	oneDriveClient := onedrive.NewClient(client)
 

--- a/models/disk/OneDriveDisk/OneDriveDisk.go
+++ b/models/disk/OneDriveDisk/OneDriveDisk.go
@@ -428,6 +428,8 @@ func (d *OneDriveDisk) IsReady(ctx *gin.Context) bool {
 }
 
 func (d *OneDriveDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
+	_disk.Credentials = ""
+
 	return &models.DiskResponse{
 		Disk:    *_disk,
 		Array:   nil,

--- a/models/disk/SFTPDisk/SFTPDisk.go
+++ b/models/disk/SFTPDisk/SFTPDisk.go
@@ -268,6 +268,10 @@ func (d *SFTPDisk) IsReady() bool {
 	return d.abstractDisk.IsReady()
 }
 
+func (d *SFTPDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
+	return d.abstractDisk.GetResponse(_disk)
+}
+
 /* Factory methods */
 func NewSFTPDisk() *SFTPDisk {
 	var d *SFTPDisk = new(SFTPDisk)

--- a/models/disk/SFTPDisk/SFTPDisk.go
+++ b/models/disk/SFTPDisk/SFTPDisk.go
@@ -10,6 +10,7 @@ import (
 	"dcfs/models/disk/AbstractDisk"
 	"dcfs/util/logger"
 	"fmt"
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/pkg/sftp"
 	"io"
@@ -264,12 +265,12 @@ func (d *SFTPDisk) AssignDisk(disk models.Disk) {
 	d.abstractDisk.AssignDisk(disk)
 }
 
-func (d *SFTPDisk) IsReady() bool {
-	return d.abstractDisk.IsReady()
+func (d *SFTPDisk) IsReady(ctx *gin.Context) bool {
+	return d.abstractDisk.IsReady(ctx)
 }
 
-func (d *SFTPDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
-	return d.abstractDisk.GetResponse(_disk)
+func (d *SFTPDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
+	return d.abstractDisk.GetResponse(_disk, ctx)
 }
 
 /* Factory methods */

--- a/models/disk/SFTPDisk/SFTPDisk.go
+++ b/models/disk/SFTPDisk/SFTPDisk.go
@@ -2,6 +2,7 @@ package SFTPDisk
 
 import (
 	"bytes"
+	"context"
 	"dcfs/apicalls"
 	"dcfs/constants"
 	"dcfs/db/dbo"
@@ -265,8 +266,8 @@ func (d *SFTPDisk) AssignDisk(disk models.Disk) {
 	d.abstractDisk.AssignDisk(disk)
 }
 
-func (d *SFTPDisk) IsReady(ctx *gin.Context) bool {
-	return d.abstractDisk.IsReady(ctx)
+func (d *SFTPDisk) GetReadiness() models.DiskReadiness {
+	return d.abstractDisk.DiskReadiness
 }
 
 func (d *SFTPDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
@@ -277,6 +278,18 @@ func (d *SFTPDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskRe
 func NewSFTPDisk() *SFTPDisk {
 	var d *SFTPDisk = new(SFTPDisk)
 	d.abstractDisk.Disk = d
+	d.abstractDisk.DiskReadiness = models.NewRealDiskReadiness(func(ctx context.Context) bool {
+		logger.Logger.Debug("drive", "Checking readiness for SFTP drive: ", d.GetUUID().String(), ".")
+		if d.GetCredentials().Authenticate(&apicalls.CredentialsAuthenticateMetadata{
+			Ctx:      ctx,
+			Config:   nil,
+			DiskUUID: d.GetUUID(),
+		}) == nil {
+			return false
+		}
+
+		return true
+	}, func() bool { return models.Transport.ActiveVolumes.GetEnqueuedInstance(d.GetVolume().UUID) != nil })
 	return d
 }
 

--- a/models/diskReadiness.go
+++ b/models/diskReadiness.go
@@ -1,0 +1,151 @@
+package models
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type DiskReadiness interface {
+	IsReady(ctx context.Context) bool
+	IsReadyForce(ctx context.Context) bool
+	IsReadyForceNonBlocking(ctx context.Context) bool
+}
+
+type RealDiskReadiness struct {
+	isReady    bool
+	isReadyMtx sync.Mutex
+
+	isReadyCheckQueued    bool
+	isReadyCheckQueuedMtx sync.Mutex
+
+	readinessChecker func(ctx context.Context) bool
+	alivenessChecker func() bool
+}
+
+func (dr *RealDiskReadiness) IsReady(ctx context.Context) bool {
+	dr.isReadyMtx.Lock()
+	defer dr.isReadyMtx.Unlock()
+
+	if dr.isReady {
+		// check readiness in 6 minutes
+		dr.isReadyPeriodicCheck(3*time.Minute, ctx)
+		return true
+	}
+
+	// check readiness now
+	dr.isReadyPeriodicCheck(0, ctx)
+	return false
+}
+
+func (dr *RealDiskReadiness) isReadyPeriodicCheck(timeout time.Duration, ctx context.Context) {
+	dr.isReadyCheckQueuedMtx.Lock()
+	defer dr.isReadyCheckQueuedMtx.Unlock()
+
+	// check if another call to check readiness is queued
+	if dr.isReadyCheckQueued {
+		return
+	}
+
+	dr.isReadyCheckQueued = true
+	go func() {
+		time.Sleep(timeout)
+
+		dr.isReadyMtx.Lock()
+		defer dr.isReadyMtx.Unlock()
+
+		dr.isReady = dr.readinessChecker(ctx)
+
+		dr.isReadyCheckQueuedMtx.Lock()
+		defer dr.isReadyCheckQueuedMtx.Unlock()
+
+		dr.isReadyCheckQueued = false
+
+		if !dr.alivenessChecker() {
+			return
+		}
+
+		// run the periodic check again in the background
+		go dr.isReadyPeriodicCheck(3*time.Minute, ctx)
+	}()
+}
+
+func (dr *RealDiskReadiness) IsReadyForce(ctx context.Context) bool {
+	dr.isReadyMtx.Lock()
+	defer dr.isReadyMtx.Unlock()
+
+	dr.isReady = dr.readinessChecker(ctx)
+	return dr.isReady
+}
+
+func (dr *RealDiskReadiness) IsReadyForceNonBlocking(ctx context.Context) bool {
+	dr.isReadyMtx.Lock()
+	defer dr.isReadyMtx.Unlock()
+
+	go func(ctx context.Context) {
+		time.Sleep(time.Second)
+
+		dr.isReadyMtx.Lock()
+		defer dr.isReadyMtx.Unlock()
+
+		dr.isReady = dr.readinessChecker(ctx)
+	}(ctx)
+
+	return dr.isReady
+}
+
+func NewRealDiskReadiness(readinessChecker func(ctx context.Context) bool, alivenessChecker func() bool) DiskReadiness {
+	return &RealDiskReadiness{
+		isReady:               true,
+		isReadyMtx:            sync.Mutex{},
+		isReadyCheckQueued:    false,
+		isReadyCheckQueuedMtx: sync.Mutex{},
+		readinessChecker:      readinessChecker,
+		alivenessChecker:      alivenessChecker,
+	}
+}
+
+type VirtualDiskReadiness struct {
+	RealDiskReadinessObjects []DiskReadiness
+}
+
+func NewVirtualDiskReadiness(objects ...DiskReadiness) *VirtualDiskReadiness {
+	vdr := &VirtualDiskReadiness{}
+
+	if objects == nil || len(objects) == 0 {
+		return vdr
+	}
+
+	arr := make([]DiskReadiness, 0)
+	for _, obj := range objects {
+		if obj == nil {
+			continue
+		}
+		arr = append(arr, obj)
+	}
+
+	vdr.RealDiskReadinessObjects = arr
+	return vdr
+}
+
+func (vdr *VirtualDiskReadiness) forAll(op func(dr DiskReadiness) bool) bool {
+	for _, obj := range vdr.RealDiskReadinessObjects {
+		if op(obj) == false {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (vdr *VirtualDiskReadiness) IsReady(ctx context.Context) bool {
+	return vdr.forAll(func(dr DiskReadiness) bool { return dr.IsReady(ctx) })
+}
+
+func (vdr *VirtualDiskReadiness) IsReadyForce(ctx context.Context) bool {
+	return vdr.forAll(func(dr DiskReadiness) bool { return dr.IsReadyForce(ctx) })
+}
+
+func (vdr *VirtualDiskReadiness) IsReadyForceNonBlocking(ctx context.Context) bool {
+	return vdr.forAll(func(dr DiskReadiness) bool { return dr.IsReadyForceNonBlocking(ctx) })
+}

--- a/models/volume.go
+++ b/models/volume.go
@@ -549,8 +549,10 @@ func NewVolume(_volume *dbo.Volume, _disks []dbo.Disk, _virtualDisks []dbo.Disk)
 		v.InitializeBackup(_virtualDisks)
 	}
 
-	go func() { v.RefreshPartitioner() }()
+	RefreshPartitionerFunc(v)
 
 	log.Println("Created a new Volume: ", v)
 	return v
 }
+
+var RefreshPartitionerFunc func(v *Volume) = func(v *Volume) { go func() { v.RefreshPartitioner() }() }

--- a/models/volume.go
+++ b/models/volume.go
@@ -9,6 +9,7 @@ import (
 	"dcfs/db/dbo"
 	"dcfs/requests"
 	"dcfs/util/logger"
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"io"
@@ -481,15 +482,13 @@ func (v *Volume) Decrypt(block *[]uint8) error {
 // IsReady - check if the volume is ready to begin operations on files
 //
 // return type: bool
-func (v *Volume) IsReady() bool {
-	disks := v.GetDisks()
-
-	if len(disks) == 0 {
+func (v *Volume) IsReady(ctx *gin.Context) bool {
+	if len(v.disks) == 0 {
 		return false
 	}
 
-	for _, d := range disks {
-		if !d.IsReady() {
+	for _, d := range v.disks {
+		if !d.IsReady(ctx) {
 			return false
 		}
 	}

--- a/models/volume.go
+++ b/models/volume.go
@@ -487,6 +487,12 @@ func (v *Volume) IsReady(ctx *gin.Context) bool {
 		return false
 	}
 
+	if v.VolumeSettings.Encryption == constants.ENCRYPTION_TYPE_AES_256 {
+		if 2*len(v.virtualDisks) != len(v.disks) {
+			return false
+		}
+	}
+
 	for _, d := range v.disks {
 		if !d.IsReady(ctx) {
 			return false

--- a/models/volume.go
+++ b/models/volume.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -482,7 +483,7 @@ func (v *Volume) Decrypt(block *[]uint8) error {
 // IsReady - check if the volume is ready to begin operations on files
 //
 // return type: bool
-func (v *Volume) IsReady(ctx *gin.Context) bool {
+func (v *Volume) IsReady(ctx *gin.Context, blocking bool) bool {
 	if len(v.disks) == 0 {
 		return false
 	}
@@ -494,8 +495,14 @@ func (v *Volume) IsReady(ctx *gin.Context) bool {
 	}
 
 	for _, d := range v.disks {
-		if !d.IsReady(ctx) {
-			return false
+		if blocking {
+			if !d.GetReadiness().IsReadyForce(ctx) {
+				return false
+			}
+		} else {
+			if !d.GetReadiness().IsReady(ctx) {
+				return false
+			}
 		}
 	}
 
@@ -534,6 +541,7 @@ func NewVolume(_volume *dbo.Volume, _disks []dbo.Disk, _virtualDisks []dbo.Disk)
 
 		if d != nil {
 			v.AddDisk(d.GetUUID(), d)
+			d.GetReadiness().IsReadyForceNonBlocking(context.TODO())
 		}
 	}
 
@@ -541,7 +549,7 @@ func NewVolume(_volume *dbo.Volume, _disks []dbo.Disk, _virtualDisks []dbo.Disk)
 		v.InitializeBackup(_virtualDisks)
 	}
 
-	v.RefreshPartitioner()
+	go func() { v.RefreshPartitioner() }()
 
 	log.Println("Created a new Volume: ", v)
 	return v

--- a/test/unit/mock/mock_disk.go
+++ b/test/unit/mock/mock_disk.go
@@ -1,12 +1,14 @@
 package mock
 
 import (
+	"context"
 	"dcfs/apicalls"
 	"dcfs/constants"
 	"dcfs/db/dbo"
 	"dcfs/models"
 	"dcfs/models/credentials"
 	"fmt"
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"os"
 	"time"
@@ -21,7 +23,8 @@ type MockDisk struct {
 	UsedSpace  uint64
 	TotalSpace uint64
 
-	CreationTime time.Time
+	CreationTime  time.Time
+	DiskReadiness *MockDiskReadiness
 }
 
 /* Mandatory Disk interface implementations */
@@ -175,18 +178,40 @@ func (d *MockDisk) AssignDisk(disk models.Disk) {
 	panic("Unimplemented")
 }
 
-func (d *MockDisk) IsReady() bool {
+func (d *MockDisk) GetReadiness() models.DiskReadiness {
+	return d.DiskReadiness
+}
+
+func (d *MockDisk) GetResponse(_disk *dbo.Disk, ctx *gin.Context) *models.DiskResponse {
+	return nil
+}
+
+type MockDiskReadiness struct{}
+
+func (mdr *MockDiskReadiness) IsReady(ctx context.Context) bool {
 	return true
 }
 
-func (d *MockDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
-	return nil
+func (mdr *MockDiskReadiness) IsReadyForce(ctx context.Context) bool {
+	return true
+}
+
+func (mdr *MockDiskReadiness) IsReadyForceNonBlocking(ctx context.Context) bool {
+	return true
 }
 
 func NewMockDisk() models.Disk {
 	var d *MockDisk = new(MockDisk)
 
 	d.CreationTime = time.Now()
+	d.DiskReadiness = new(MockDiskReadiness)
+
+	return d
+}
+
+func CreateMockDisk(_d dbo.Disk) models.Disk {
+	d := NewMockDisk()
+	d.SetCreationTime(_d.GetCreationTime())
 
 	return d
 }

--- a/test/unit/mock/mock_disk.go
+++ b/test/unit/mock/mock_disk.go
@@ -179,6 +179,10 @@ func (d *MockDisk) IsReady() bool {
 	return true
 }
 
+func (d *MockDisk) GetResponse(_disk *dbo.Disk) *models.DiskResponse {
+	return nil
+}
+
 func NewMockDisk() models.Disk {
 	var d *MockDisk = new(MockDisk)
 

--- a/test/unit/ut_disk_test.go
+++ b/test/unit/ut_disk_test.go
@@ -44,9 +44,9 @@ func TestCreateDiskFromUUID(t *testing.T) {
 	provider, _ := mock.GetProviderDBO(disks[0].Provider.Type)
 	// volume := MockNewVolume(*mock.VolumeDBO, disks, false)
 
-	mock.DBMock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `disks` WHERE uuid = ? ORDER BY `disks`.`uuid` LIMIT 1")).
-		WithArgs(disks[0].UUID).
-		WillReturnRows(mock.DiskRow(&disks[0]))
+	//mock.DBMock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `disks` WHERE uuid = ? ORDER BY `disks`.`uuid` LIMIT 1")).
+	//	WithArgs(disks[0].UUID).
+	//	WillReturnRows(mock.DiskRow(&disks[0]))
 
 	Convey("CreateDiskFromUUID function works correctly", t, func() {
 		Convey("Should return nil if the disk does not exist", func() {
@@ -178,4 +178,11 @@ func CreateDummyDisk(disk *dbo.Disk, provider *dbo.Provider, dry_run bool) model
 	models.Transport.ActiveVolumes.RemoveEnqueuedInstance(disk.VolumeUUID)
 
 	return _disk
+}
+
+func init() {
+	models.DiskReadinessRegistry[constants.PROVIDER_TYPE_SFTP] = func(d models.Disk) models.DiskReadiness { return &mock.MockDiskReadiness{} }
+	models.DiskReadinessRegistry[constants.PROVIDER_TYPE_FTP] = func(d models.Disk) models.DiskReadiness { return &mock.MockDiskReadiness{} }
+	models.DiskReadinessRegistry[constants.PROVIDER_TYPE_ONEDRIVE] = func(d models.Disk) models.DiskReadiness { return &mock.MockDiskReadiness{} }
+	models.DiskReadinessRegistry[constants.PROVIDER_TYPE_GDRIVE] = func(d models.Disk) models.DiskReadiness { return &mock.MockDiskReadiness{} }
 }

--- a/test/unit/ut_partitioner_test.go
+++ b/test/unit/ut_partitioner_test.go
@@ -322,6 +322,9 @@ func TestThroughputPartitioner_AssignBlocks(t *testing.T) {
 	volume := MockNewVolume(*mock.VolumeDBO, disks, true)
 	partitioner := volume.GetPartitioner()
 
+	partitioner.(*models.ThroughputPartitioner).Weights[0] = 100
+	partitioner.(*models.ThroughputPartitioner).Weights[0] = 1
+
 	Convey("Test if throughput partitioner assigns more blocks to faster disk", t, func() {
 		numberOfBlocks := 10
 


### PR DESCRIPTION
getDisk and getDisks return objects that contain two additonal fields:
- `json:"array"` - array of disks when the parent disk is protected by raid / otherwise null
- `json:"isReady"` - a flag that indicates whether a disk is ready for file operations

Signed-off-by: Brotholomew <bartoszek.blach@gmail.com>